### PR TITLE
Updated Logcat Invocation & Demo

### DIFF
--- a/demo/src/main/java/com/vrazo/logcat/demo/MainActivity.java
+++ b/demo/src/main/java/com/vrazo/logcat/demo/MainActivity.java
@@ -111,10 +111,10 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         logCatDelegate.addMessageFilter(logCatMessageFilter);
         //
         // This filter will only display message with the INFO priority.
-        logCatPriorityFilter = new LogCatPriorityFilter(new ArrayList<LogCatPriority>() {{
-            add(new LogCatPriority(Log.INFO));
-        }});
-        logCatDelegate.addMessageFilter(logCatPriorityFilter);
+        // logCatPriorityFilter = new LogCatPriorityFilter(new ArrayList<LogCatPriority>() {{
+        //    add(new LogCatPriority(Log.INFO));
+        // }});
+        // logCatDelegate.addMessageFilter(logCatPriorityFilter);
     }
 
     /**

--- a/logcatdelegate/src/main/java/com/vrazo/logcat/LogCatDelegate.java
+++ b/logcatdelegate/src/main/java/com/vrazo/logcat/LogCatDelegate.java
@@ -14,6 +14,7 @@ public abstract class LogCatDelegate {
     /**
      * Type definition for initialization exceptions.
      */
+    @SuppressWarnings("WeakerAccess")
     public final static class InitializationException extends Exception {
         InitializationException(String error) {
             super(error);
@@ -101,7 +102,7 @@ public abstract class LogCatDelegate {
                                 "command line argument."
                             );
                         }
-                        mProcess = Runtime.getRuntime().exec("logcat " + cliArgs + " -v threadtime,epoch");
+                        mProcess = Runtime.getRuntime().exec("logcat " + cliArgs + " -v threadtime");
                         int exitCode = 0;
                         try {
                             exitCode = mProcess.exitValue();


### PR DESCRIPTION
1. Updated the logcat invocation to use threadtime format without epoch
   timestamps due to older devices not supporting the epoch format
   modifier when calling logcat.
2. Updated the demo application to not apply the priority filter to
   incoming messages since it made the demo somewhat confusing.